### PR TITLE
Update to Mongo 4.2 db.aggregate()

### DIFF
--- a/mongo/queries/koeln.js
+++ b/mongo/queries/koeln.js
@@ -1,16 +1,20 @@
 // Datei: db/mongo/queries/koeln.js
-let dom = db.geoname.findOne({
-  name: /Köln.*Dom/
-});
-let res = db.runCommand({
-  geoNear: "geoname",
-  near: dom.location,
-  maxDistance: 1000,
-  spherical: true,
-  query: {
-    feature_code: 'HTL'
-  }
-})
-res.results.forEach(data => {
-  print(Math.round(data.dis)+ "m: " + data.obj.name);
+let dom = db.geoname.findOne({name: /Köln.*Dom/});
+let res = db.geoname.aggregate([
+  {
+    $geoNear: {
+       near: dom.location,
+       key: "location",
+       distanceField: "dist.calculated",
+       maxDistance: 1000,
+       query: { feature_code: 'HTL' },
+       spherical: true
+    }
+  },
+  { $limit: 10 },
+  { $sort : { "dist.calculated" : -1, name: 1} }
+])
+
+res._batch.forEach(data => {
+  print(Math.round(data.dist.calculated)+ "m: " + data.name);
 })


### PR DESCRIPTION
Updated to `db.aggregate()` as mongo 4.2 no longer supports geoNear run command